### PR TITLE
Change li element type to decimal

### DIFF
--- a/dist/css/style.css
+++ b/dist/css/style.css
@@ -1,5 +1,5 @@
 li {
-  list-style-type: none; }
+  list-style-type: decimal; }
 
 span {
   display: inline;

--- a/styles/style.scss
+++ b/styles/style.scss
@@ -3,7 +3,7 @@ $primary-color: #c4da87;
 $secondary-color: #4fab53;
 
 li {
-  list-style-type: none;
+  list-style-type: decimal;
 }
 
 span {


### PR DESCRIPTION
Quicklinks on frontpage are marked with numbers